### PR TITLE
Add monthly video compilations and gallery UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ COPY app.py /app/app.py
 COPY sun.py /app/sun.py
 COPY start_collection.py /app/start_collection.py
 COPY endpoint.sh /app/endpoint.sh
+COPY collage.py /app/collage.py
+COPY concat.py /app/concat.py
+COPY static/ /app/static/
 
 # Ensure scripts have executable permissions
 RUN chmod +x /app/*.sh /app/*.py

--- a/app.py
+++ b/app.py
@@ -2,7 +2,8 @@ import json
 from collections import UserDict
 from datetime import datetime
 from fastapi import FastAPI, Query, Request, WebSocket, WebSocketDisconnect, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
 from google.cloud import storage
 from typing import Optional
 import asyncio
@@ -14,6 +15,7 @@ import uuid
 import urllib.request
 
 import collage
+import concat
 
 app = FastAPI()
 
@@ -276,7 +278,16 @@ async def collect_and_upload_video(job_id: str, youtube_url: str):
 @app.get("/")
 async def root():
     version_info = ("BUILD_TIME: " + BUILD_TIME) if BUILD_TIME else ("SERVER_START_TIME: " + SERVER_START_TIME)
-    return JSONResponse({"message": "Camera Collector API is running!", "version": version_info})
+    return JSONResponse({
+        "message": "Camera Collector API is running!",
+        "version": version_info,
+        "gallery_url": "/gallery",
+        "api_endpoints": {
+            "months": "/api/months",
+            "generate_compilation": "/api/compilation/generate",
+            "compilation_status": "/api/compilation/{year}/{month}",
+        }
+    })
 
 @app.post("/collection/start/{youtube_url:path}")
 async def start_collection(youtube_url: Optional[str] = None):
@@ -404,6 +415,123 @@ async def websocket_latest_endpoint(websocket: WebSocket):
             await websocket.receive_text()  # Keep connection alive
     except WebSocketDisconnect:
         latest_video_manager.disconnect(websocket)
+
+
+# ============================================================================
+# Monthly Compilation API Endpoints
+# ============================================================================
+
+
+@app.get("/api/months")
+async def list_months():
+    """
+    List all available months with video counts and compilation status.
+
+    Returns a list of months that have videos, along with counts for
+    sunrise/sunset videos and whether compilations exist.
+    """
+    logging.info("Fetching available months")
+    try:
+        months = await asyncio.to_thread(
+            concat.list_available_months,
+            storage_client,
+            BUCKET_NAME,
+        )
+        return JSONResponse({"months": months})
+    except Exception as e:
+        logging.error(f"Error listing months: {e}")
+        raise HTTPException(status_code=500, detail=f"Error listing months: {str(e)}")
+
+
+@app.post("/api/compilation/generate")
+async def generate_compilation(
+    year: int = Query(..., description="Year of the compilation"),
+    month: int = Query(..., description="Month of the compilation (1-12)"),
+    time_filter: Optional[str] = Query(None, description="Filter: 'sunrise', 'sunset', or omit for all"),
+    force: bool = Query(False, description="Force regeneration even if cached"),
+):
+    """
+    Generate or retrieve a monthly video compilation.
+
+    Concatenates daily videos into a monthly compilation. If a compilation
+    already exists, returns the cached version unless force=true.
+    """
+    logging.info(f"Generating compilation: year={year}, month={month}, time_filter={time_filter}, force={force}")
+
+    # Validate inputs
+    if month < 1 or month > 12:
+        raise HTTPException(status_code=400, detail="month must be between 1 and 12")
+    if time_filter and time_filter not in ("sunrise", "sunset"):
+        raise HTTPException(status_code=400, detail="time_filter must be 'sunrise' or 'sunset'")
+
+    try:
+        result = await asyncio.to_thread(
+            concat.generate_compilation,
+            storage_client,
+            BUCKET_NAME,
+            year=year,
+            month=month,
+            time_filter=time_filter,
+            force_regenerate=force,
+        )
+        logging.info(f"Compilation result: {result}")
+        return JSONResponse(result)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logging.error(f"Error generating compilation: {e}")
+        raise HTTPException(status_code=500, detail=f"Error generating compilation: {str(e)}")
+
+
+@app.get("/api/compilation/{year}/{month}")
+async def get_compilation_status(
+    year: int,
+    month: int,
+    time_filter: Optional[str] = Query(None, description="Filter: 'sunrise', 'sunset', or omit for all"),
+):
+    """
+    Get status and metadata for a compilation.
+
+    Returns whether the compilation exists and its metadata if it does.
+    """
+    logging.info(f"Checking compilation status: year={year}, month={month}, time_filter={time_filter}")
+
+    # Validate inputs
+    if month < 1 or month > 12:
+        raise HTTPException(status_code=400, detail="month must be between 1 and 12")
+    if time_filter and time_filter not in ("sunrise", "sunset"):
+        raise HTTPException(status_code=400, detail="time_filter must be 'sunrise' or 'sunset'")
+
+    try:
+        blob_name = concat.get_compilation_blob_name(year, month, time_filter)
+        result = await asyncio.to_thread(
+            concat.check_compilation_exists,
+            storage_client,
+            BUCKET_NAME,
+            blob_name,
+        )
+        return JSONResponse(result)
+    except Exception as e:
+        logging.error(f"Error checking compilation: {e}")
+        raise HTTPException(status_code=500, detail=f"Error checking compilation: {str(e)}")
+
+
+# ============================================================================
+# Gallery Static Files
+# ============================================================================
+
+
+@app.get("/gallery")
+async def gallery():
+    """
+    Serve the gallery single-page application.
+    """
+    return FileResponse("static/index.html")
+
+
+# Mount static files directory
+# Note: This must be after all other routes to avoid catching API routes
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
 if __name__ == "__main__":

--- a/app_test.py
+++ b/app_test.py
@@ -448,3 +448,167 @@ class TestLookupExternalIP:
         with patch('urllib.request.urlopen', return_value=mock_response):
             ip = lookup_external_ip()
             assert ip == "192.168.1.1"
+
+
+class TestListMonthsEndpoint:
+    def test_list_months_success(self):
+        """Test GET /api/months returns months data."""
+        mock_months = [
+            {"year": 2025, "month": 1, "sunrise_count": 31, "sunset_count": 28},
+        ]
+
+        with patch('app.concat.list_available_months', return_value=mock_months):
+            response = client.get("/api/months")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "months" in data
+        assert len(data["months"]) == 1
+        assert data["months"][0]["year"] == 2025
+
+    def test_list_months_empty(self):
+        """Test GET /api/months when no months available."""
+        with patch('app.concat.list_available_months', return_value=[]):
+            response = client.get("/api/months")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["months"] == []
+
+    def test_list_months_error(self):
+        """Test GET /api/months handles errors."""
+        with patch('app.concat.list_available_months', side_effect=Exception("GCS error")):
+            response = client.get("/api/months")
+
+        assert response.status_code == 500
+        assert "GCS error" in response.json()["detail"]
+
+
+class TestGenerateCompilationEndpoint:
+    def test_generate_compilation_success(self):
+        """Test POST /api/compilation/generate creates compilation."""
+        mock_result = {
+            "url": "https://storage.googleapis.com/test/compilation.mp4",
+            "video_count": 30,
+            "duration_seconds": 450.0,
+            "cached": False,
+        }
+
+        with patch('app.concat.generate_compilation', return_value=mock_result):
+            response = client.post("/api/compilation/generate?year=2025&month=1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["url"] == mock_result["url"]
+        assert data["video_count"] == 30
+
+    def test_generate_compilation_with_time_filter(self):
+        """Test POST /api/compilation/generate with time_filter."""
+        mock_result = {"url": "https://test.url", "cached": True}
+
+        with patch('app.concat.generate_compilation', return_value=mock_result) as mock_gen:
+            response = client.post(
+                "/api/compilation/generate?year=2025&month=1&time_filter=sunset"
+            )
+
+        assert response.status_code == 200
+        # Verify time_filter was passed
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["time_filter"] == "sunset"
+
+    def test_generate_compilation_invalid_month(self):
+        """Test POST /api/compilation/generate with invalid month."""
+        response = client.post("/api/compilation/generate?year=2025&month=13")
+        assert response.status_code == 400
+        assert "month must be between 1 and 12" in response.json()["detail"]
+
+    def test_generate_compilation_invalid_time_filter(self):
+        """Test POST /api/compilation/generate with invalid time_filter."""
+        response = client.post(
+            "/api/compilation/generate?year=2025&month=1&time_filter=noon"
+        )
+        assert response.status_code == 400
+        assert "time_filter must be" in response.json()["detail"]
+
+    def test_generate_compilation_no_videos(self):
+        """Test POST /api/compilation/generate when no videos found."""
+        with patch('app.concat.generate_compilation', side_effect=ValueError("No videos found")):
+            response = client.post("/api/compilation/generate?year=2025&month=1")
+
+        assert response.status_code == 404
+        assert "No videos found" in response.json()["detail"]
+
+    def test_generate_compilation_force_regenerate(self):
+        """Test POST /api/compilation/generate with force=true."""
+        mock_result = {"url": "https://test.url", "cached": False}
+
+        with patch('app.concat.generate_compilation', return_value=mock_result) as mock_gen:
+            response = client.post(
+                "/api/compilation/generate?year=2025&month=1&force=true"
+            )
+
+        assert response.status_code == 200
+        call_kwargs = mock_gen.call_args[1]
+        assert call_kwargs["force_regenerate"] is True
+
+
+class TestGetCompilationStatusEndpoint:
+    def test_get_compilation_exists(self):
+        """Test GET /api/compilation/{year}/{month} when compilation exists."""
+        mock_result = {
+            "exists": True,
+            "url": "https://storage.googleapis.com/test/compilation.mp4",
+            "size_bytes": 100000000,
+        }
+
+        with patch('app.concat.check_compilation_exists', return_value=mock_result):
+            response = client.get("/api/compilation/2025/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exists"] is True
+        assert "url" in data
+
+    def test_get_compilation_not_exists(self):
+        """Test GET /api/compilation/{year}/{month} when not exists."""
+        mock_result = {"exists": False}
+
+        with patch('app.concat.check_compilation_exists', return_value=mock_result):
+            response = client.get("/api/compilation/2025/1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exists"] is False
+
+    def test_get_compilation_with_time_filter(self):
+        """Test GET /api/compilation/{year}/{month} with time_filter."""
+        mock_result = {"exists": True}
+
+        with patch('app.concat.get_compilation_blob_name', return_value="test.mp4") as mock_name, \
+             patch('app.concat.check_compilation_exists', return_value=mock_result):
+            response = client.get("/api/compilation/2025/1?time_filter=sunrise")
+
+        assert response.status_code == 200
+        mock_name.assert_called_once_with(2025, 1, "sunrise")
+
+    def test_get_compilation_invalid_month(self):
+        """Test GET /api/compilation/{year}/{month} with invalid month."""
+        response = client.get("/api/compilation/2025/0")
+        assert response.status_code == 400
+
+    def test_get_compilation_invalid_time_filter(self):
+        """Test GET /api/compilation/{year}/{month} with invalid time_filter."""
+        response = client.get("/api/compilation/2025/1?time_filter=invalid")
+        assert response.status_code == 400
+
+
+class TestGalleryEndpoint:
+    def test_gallery_serves_html(self):
+        """Test GET /gallery serves the index.html file."""
+        with patch('app.FileResponse') as mock_response:
+            mock_response.return_value = MagicMock()
+            # The actual endpoint will try to serve the file
+            # We just verify the route exists and returns 200 or handles missing file
+            response = client.get("/gallery")
+            # Will be 404 if file doesn't exist in test env, which is expected
+            assert response.status_code in (200, 404)

--- a/concat.py
+++ b/concat.py
@@ -1,0 +1,440 @@
+"""
+Video concatenation module for camera-collector.
+
+This module provides functionality to concatenate daily sunrise/sunset videos
+into monthly compilation videos stored in Google Cloud Storage.
+"""
+
+import logging
+import os
+import subprocess
+import tempfile
+from datetime import datetime
+from typing import Optional
+
+from google.cloud import storage
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
+
+# Approximate times for filtering sunrise vs sunset (in 24h format)
+SUNRISE_HOUR_RANGE = (5, 10)  # 5 AM to 10 AM
+SUNSET_HOUR_RANGE = (16, 21)  # 4 PM to 9 PM
+
+
+def extract_hour_from_filename(filename: str) -> Optional[int]:
+    """
+    Extract the hour from a video filename.
+
+    Expected format: seacliff-YYYY-MM-DDTHH:MM-SS+ZZZZ.mp4
+
+    Args:
+        filename: The video filename
+
+    Returns:
+        Hour as integer, or None if parsing fails
+    """
+    try:
+        basename = os.path.basename(filename)
+        timestamp_part = basename.replace("seacliff-", "").replace(".mp4", "")
+        hour_str = timestamp_part.split("T")[1].split(":")[0]
+        return int(hour_str)
+    except (IndexError, ValueError):
+        return None
+
+
+def list_videos_for_month(
+    storage_client: storage.Client,
+    bucket_name: str,
+    year: int,
+    month: int,
+    time_filter: Optional[str] = None,
+) -> list[str]:
+    """
+    List video blobs from GCS for a specific month.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        year: Year to filter by
+        month: Month to filter by
+        time_filter: "sunrise", "sunset", or None for all videos
+
+    Returns:
+        List of blob names matching the filters, sorted chronologically
+    """
+    prefix = f"{year}/{month:02d}/"
+    bucket = storage_client.bucket(bucket_name)
+    blobs = bucket.list_blobs(prefix=prefix)
+
+    video_blobs = []
+    for blob in blobs:
+        # Skip non-video files and files in subdirectories (collages, compilations)
+        if not blob.name.endswith(".mp4"):
+            continue
+        if "/collages/" in blob.name or "/compilations/" in blob.name:
+            continue
+
+        # Apply time filter if specified
+        if time_filter:
+            hour = extract_hour_from_filename(blob.name)
+            if hour is not None:
+                if time_filter == "sunrise" and not (SUNRISE_HOUR_RANGE[0] <= hour <= SUNRISE_HOUR_RANGE[1]):
+                    continue
+                elif time_filter == "sunset" and not (SUNSET_HOUR_RANGE[0] <= hour <= SUNSET_HOUR_RANGE[1]):
+                    continue
+
+        video_blobs.append(blob.name)
+
+    # Sort by filename (which contains timestamp) for chronological order
+    video_blobs.sort()
+    return video_blobs
+
+
+def get_video_counts_for_month(
+    storage_client: storage.Client,
+    bucket_name: str,
+    year: int,
+    month: int,
+) -> dict:
+    """
+    Get counts of sunrise and sunset videos for a month.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        year: Year to count
+        month: Month to count
+
+    Returns:
+        Dictionary with sunrise_count, sunset_count, and total_count
+    """
+    sunrise_videos = list_videos_for_month(storage_client, bucket_name, year, month, "sunrise")
+    sunset_videos = list_videos_for_month(storage_client, bucket_name, year, month, "sunset")
+    all_videos = list_videos_for_month(storage_client, bucket_name, year, month, None)
+
+    return {
+        "sunrise_count": len(sunrise_videos),
+        "sunset_count": len(sunset_videos),
+        "total_count": len(all_videos),
+    }
+
+
+def get_compilation_blob_name(year: int, month: int, time_filter: Optional[str]) -> str:
+    """
+    Generate the blob name for a compilation video.
+
+    Args:
+        year: Year of the compilation
+        month: Month of the compilation
+        time_filter: "sunrise", "sunset", or None for all
+
+    Returns:
+        Blob name for the compilation
+    """
+    filter_name = time_filter if time_filter else "all"
+    return f"{year}/{month:02d}/compilations/{filter_name}-{year}-{month:02d}.mp4"
+
+
+def check_compilation_exists(
+    storage_client: storage.Client,
+    bucket_name: str,
+    blob_name: str,
+) -> dict:
+    """
+    Check if a compilation video already exists in GCS.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        blob_name: Name of the compilation blob
+
+    Returns:
+        Dictionary with exists, url, size_bytes, and updated fields
+    """
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+
+    if blob.exists():
+        blob.reload()
+        return {
+            "exists": True,
+            "url": f"https://storage.googleapis.com/{bucket_name}/{blob_name}",
+            "size_bytes": blob.size,
+            "updated": blob.updated.isoformat() if blob.updated else None,
+        }
+
+    return {"exists": False}
+
+
+def download_video_from_gcs(
+    storage_client: storage.Client,
+    bucket_name: str,
+    blob_name: str,
+    local_path: str,
+) -> None:
+    """
+    Download a video from GCS to a local path.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        blob_name: Name of the blob to download
+        local_path: Local path to save the video
+    """
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.download_to_filename(local_path)
+    logging.info(f"Downloaded {blob_name} to {local_path}")
+
+
+def concatenate_videos(video_paths: list[str], output_path: str) -> None:
+    """
+    Concatenate multiple videos using ffmpeg concat demuxer (no re-encoding).
+
+    Args:
+        video_paths: List of local video file paths to concatenate
+        output_path: Path for the output concatenated video
+    """
+    if not video_paths:
+        raise ValueError("No video paths provided for concatenation")
+
+    # Create concat file list
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        concat_file = f.name
+        for path in video_paths:
+            # Use absolute paths and escape single quotes
+            abs_path = os.path.abspath(path)
+            f.write(f"file '{abs_path}'\n")
+
+    try:
+        cmd = [
+            "ffmpeg",
+            "-y",  # Overwrite output
+            "-f", "concat",
+            "-safe", "0",
+            "-i", concat_file,
+            "-c", "copy",  # No re-encoding
+            "-movflags", "+faststart",  # Web streaming optimization
+            output_path,
+        ]
+        logging.info(f"Concatenating {len(video_paths)} videos: {' '.join(cmd)}")
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=600,  # 10 minute timeout
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"ffmpeg concat failed: {result.stderr.decode()}")
+
+        logging.info(f"Created compilation: {output_path}")
+    finally:
+        if os.path.exists(concat_file):
+            os.remove(concat_file)
+
+
+def upload_compilation_to_gcs(
+    storage_client: storage.Client,
+    bucket_name: str,
+    local_path: str,
+    blob_name: str,
+) -> str:
+    """
+    Upload a compilation video to GCS.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        local_path: Local path of the video to upload
+        blob_name: Name for the blob in GCS
+
+    Returns:
+        Public URL of the uploaded compilation
+    """
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.upload_from_filename(local_path, content_type="video/mp4")
+
+    logging.info(f"Uploaded compilation to {blob_name}")
+    return f"https://storage.googleapis.com/{bucket_name}/{blob_name}"
+
+
+def get_video_duration(video_path: str) -> float:
+    """
+    Get the duration of a video in seconds using ffprobe.
+
+    Args:
+        video_path: Path to the video file
+
+    Returns:
+        Duration in seconds
+    """
+    cmd = [
+        "ffprobe",
+        "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        video_path,
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, timeout=30)
+    if result.returncode != 0:
+        logging.warning(f"Could not get duration for {video_path}")
+        return 0.0
+
+    try:
+        return float(result.stdout.decode().strip())
+    except ValueError:
+        return 0.0
+
+
+def generate_compilation(
+    storage_client: storage.Client,
+    bucket_name: str,
+    year: int,
+    month: int,
+    time_filter: Optional[str] = None,
+    force_regenerate: bool = False,
+) -> dict:
+    """
+    Generate a monthly compilation video from daily videos.
+
+    This function orchestrates the full workflow:
+    1. Check if compilation already exists (return cached if so)
+    2. List videos for the month
+    3. Download videos to temp directory
+    4. Concatenate using ffmpeg
+    5. Upload to GCS
+    6. Clean up temp files
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+        year: Year of videos to compile
+        month: Month of videos to compile
+        time_filter: "sunrise", "sunset", or None for all videos
+        force_regenerate: If True, regenerate even if cached version exists
+
+    Returns:
+        Dictionary with url, video_count, duration_seconds, cached, and generated_at
+    """
+    blob_name = get_compilation_blob_name(year, month, time_filter)
+
+    # Check if compilation already exists
+    if not force_regenerate:
+        existing = check_compilation_exists(storage_client, bucket_name, blob_name)
+        if existing.get("exists"):
+            logging.info(f"Using cached compilation: {blob_name}")
+            return {
+                "url": existing["url"],
+                "size_bytes": existing["size_bytes"],
+                "cached": True,
+                "generated_at": existing["updated"],
+            }
+
+    # List videos for the month
+    video_blobs = list_videos_for_month(storage_client, bucket_name, year, month, time_filter)
+
+    if not video_blobs:
+        filter_desc = f" ({time_filter})" if time_filter else ""
+        raise ValueError(f"No videos found for {year}/{month:02d}{filter_desc}")
+
+    logging.info(f"Found {len(video_blobs)} videos for compilation")
+
+    # Download, concatenate, and upload
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        local_paths = []
+
+        # Download all videos
+        for blob_name_video in video_blobs:
+            local_path = os.path.join(tmp_dir, os.path.basename(blob_name_video))
+            download_video_from_gcs(storage_client, bucket_name, blob_name_video, local_path)
+            local_paths.append(local_path)
+
+        # Concatenate videos
+        output_path = os.path.join(tmp_dir, "compilation.mp4")
+        concatenate_videos(local_paths, output_path)
+
+        # Get duration of the compilation
+        duration = get_video_duration(output_path)
+
+        # Get file size
+        file_size = os.path.getsize(output_path)
+
+        # Upload to GCS
+        url = upload_compilation_to_gcs(storage_client, bucket_name, output_path, blob_name)
+
+    return {
+        "url": url,
+        "video_count": len(video_blobs),
+        "duration_seconds": duration,
+        "size_bytes": file_size,
+        "cached": False,
+        "generated_at": datetime.now().isoformat(),
+    }
+
+
+def list_available_months(
+    storage_client: storage.Client,
+    bucket_name: str,
+) -> list[dict]:
+    """
+    List all months that have videos in the bucket.
+
+    Args:
+        storage_client: GCS client instance
+        bucket_name: Name of the GCS bucket
+
+    Returns:
+        List of dictionaries with year, month, counts, and compilation status
+    """
+    bucket = storage_client.bucket(bucket_name)
+
+    # Find all year/month prefixes by listing top-level directories
+    months_found = set()
+    blobs = bucket.list_blobs()
+
+    for blob in blobs:
+        if not blob.name.endswith(".mp4"):
+            continue
+        # Skip compilations and collages
+        if "/compilations/" in blob.name or "/collages/" in blob.name:
+            continue
+
+        # Extract year/month from path like "2025/01/seacliff-xxx.mp4"
+        parts = blob.name.split("/")
+        if len(parts) >= 2:
+            try:
+                year = int(parts[0])
+                month = int(parts[1])
+                months_found.add((year, month))
+            except ValueError:
+                continue
+
+    # Get details for each month
+    result = []
+    for year, month in sorted(months_found, reverse=True):
+        counts = get_video_counts_for_month(storage_client, bucket_name, year, month)
+
+        # Check for existing compilations
+        sunrise_blob = get_compilation_blob_name(year, month, "sunrise")
+        sunset_blob = get_compilation_blob_name(year, month, "sunset")
+        all_blob = get_compilation_blob_name(year, month, None)
+
+        has_sunrise = check_compilation_exists(storage_client, bucket_name, sunrise_blob).get("exists", False)
+        has_sunset = check_compilation_exists(storage_client, bucket_name, sunset_blob).get("exists", False)
+        has_all = check_compilation_exists(storage_client, bucket_name, all_blob).get("exists", False)
+
+        result.append({
+            "year": year,
+            "month": month,
+            "sunrise_count": counts["sunrise_count"],
+            "sunset_count": counts["sunset_count"],
+            "total_count": counts["total_count"],
+            "has_sunrise_compilation": has_sunrise,
+            "has_sunset_compilation": has_sunset,
+            "has_all_compilation": has_all,
+        })
+
+    return result

--- a/concat_test.py
+++ b/concat_test.py
@@ -1,0 +1,541 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+import tempfile
+import os
+
+from concat import (
+    list_videos_for_month,
+    get_video_counts_for_month,
+    get_compilation_blob_name,
+    check_compilation_exists,
+    download_video_from_gcs,
+    concatenate_videos,
+    upload_compilation_to_gcs,
+    get_video_duration,
+    generate_compilation,
+    list_available_months,
+    extract_hour_from_filename,
+    SUNRISE_HOUR_RANGE,
+    SUNSET_HOUR_RANGE,
+)
+
+
+class TestExtractHourFromFilename:
+    def test_extracts_hour_correctly(self):
+        """Test extracting hour from standard filename."""
+        filename = "seacliff-2025-01-24T14:30-15-0800.mp4"
+        assert extract_hour_from_filename(filename) == 14
+
+    def test_extracts_morning_hour(self):
+        """Test extracting morning hour."""
+        filename = "2025/01/seacliff-2025-01-24T06:45-00-0800.mp4"
+        assert extract_hour_from_filename(filename) == 6
+
+    def test_extracts_evening_hour(self):
+        """Test extracting evening hour."""
+        filename = "seacliff-2025-01-24T19:15-30-0800.mp4"
+        assert extract_hour_from_filename(filename) == 19
+
+    def test_returns_none_for_invalid_filename(self):
+        """Test returns None for invalid filename format."""
+        assert extract_hour_from_filename("invalid.mp4") is None
+        assert extract_hour_from_filename("no-timestamp.mp4") is None
+
+
+class TestListVideosForMonth:
+    def test_lists_videos_with_prefix(self):
+        """Test listing videos with year/month prefix."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T14:30-15-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/seacliff-2025-01-25T07:00-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert len(result) == 2
+        mock_bucket.list_blobs.assert_called_once_with(prefix="2025/01/")
+
+    def test_filters_non_mp4_files(self):
+        """Test that non-mp4 files are filtered out."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T14:30-15-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/some-image.jpg"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert len(result) == 1
+        assert result[0].endswith(".mp4")
+
+    def test_excludes_compilations_directory(self):
+        """Test that videos in compilations/ directory are excluded."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T14:30-15-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/compilations/sunset-2025-01.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert len(result) == 1
+        assert "compilations" not in result[0]
+
+    def test_excludes_collages_directory(self):
+        """Test that videos in collages/ directory are excluded."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T14:30-15-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/collages/collage.jpg"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert len(result) == 1
+        assert "collages" not in result[0]
+
+    def test_filters_by_sunset_time(self):
+        """Test filtering videos by sunset time range."""
+        mock_blob_morning = MagicMock()
+        mock_blob_morning.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+        mock_blob_evening = MagicMock()
+        mock_blob_evening.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob_morning, mock_blob_evening]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(
+            mock_client, "test-bucket", year=2025, month=1, time_filter="sunset"
+        )
+
+        assert len(result) == 1
+        assert "18:30" in result[0]
+
+    def test_filters_by_sunrise_time(self):
+        """Test filtering videos by sunrise time range."""
+        mock_blob_morning = MagicMock()
+        mock_blob_morning.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+        mock_blob_evening = MagicMock()
+        mock_blob_evening.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob_morning, mock_blob_evening]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(
+            mock_client, "test-bucket", year=2025, month=1, time_filter="sunrise"
+        )
+
+        assert len(result) == 1
+        assert "07:00" in result[0]
+
+    def test_returns_sorted_list(self):
+        """Test that results are sorted chronologically."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-25T14:30-00-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_videos_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert "01-24" in result[0]
+        assert "01-25" in result[1]
+
+
+class TestGetVideoCountsForMonth:
+    def test_returns_counts_for_all_categories(self):
+        """Test that counts are returned for sunrise, sunset, and total."""
+        mock_blob_morning = MagicMock()
+        mock_blob_morning.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+        mock_blob_evening = MagicMock()
+        mock_blob_evening.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob_morning, mock_blob_evening]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = get_video_counts_for_month(mock_client, "test-bucket", year=2025, month=1)
+
+        assert "sunrise_count" in result
+        assert "sunset_count" in result
+        assert "total_count" in result
+
+
+class TestGetCompilationBlobName:
+    def test_generates_sunrise_blob_name(self):
+        """Test generating blob name for sunrise compilation."""
+        result = get_compilation_blob_name(2025, 1, "sunrise")
+        assert result == "2025/01/compilations/sunrise-2025-01.mp4"
+
+    def test_generates_sunset_blob_name(self):
+        """Test generating blob name for sunset compilation."""
+        result = get_compilation_blob_name(2025, 1, "sunset")
+        assert result == "2025/01/compilations/sunset-2025-01.mp4"
+
+    def test_generates_all_blob_name(self):
+        """Test generating blob name for all-videos compilation."""
+        result = get_compilation_blob_name(2025, 1, None)
+        assert result == "2025/01/compilations/all-2025-01.mp4"
+
+    def test_pads_month_with_zero(self):
+        """Test that single-digit months are zero-padded."""
+        result = get_compilation_blob_name(2025, 3, "sunrise")
+        assert "03" in result
+
+
+class TestCheckCompilationExists:
+    def test_returns_true_when_exists(self):
+        """Test returns exists=True when compilation exists."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_blob.size = 100000000
+        mock_blob.updated = datetime(2025, 1, 24, 10, 30, 0)
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = check_compilation_exists(
+            mock_client, "test-bucket", "2025/01/compilations/sunset-2025-01.mp4"
+        )
+
+        assert result["exists"] is True
+        assert "url" in result
+        assert result["size_bytes"] == 100000000
+
+    def test_returns_false_when_not_exists(self):
+        """Test returns exists=False when compilation doesn't exist."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = False
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = check_compilation_exists(
+            mock_client, "test-bucket", "2025/01/compilations/sunset-2025-01.mp4"
+        )
+
+        assert result["exists"] is False
+
+
+class TestDownloadVideoFromGCS:
+    def test_downloads_to_local_path(self):
+        """Test downloading video to local path."""
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        download_video_from_gcs(
+            mock_client, "test-bucket", "2025/01/video.mp4", "/tmp/video.mp4"
+        )
+
+        mock_bucket.blob.assert_called_once_with("2025/01/video.mp4")
+        mock_blob.download_to_filename.assert_called_once_with("/tmp/video.mp4")
+
+
+class TestConcatenateVideos:
+    def test_raises_on_empty_list(self):
+        """Test that ValueError is raised when video list is empty."""
+        with pytest.raises(ValueError, match="No video paths provided"):
+            concatenate_videos([], "/tmp/output.mp4")
+
+    def test_calls_ffmpeg_with_concat_demuxer(self):
+        """Test that ffmpeg is called with concat demuxer."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Create fake video files
+            video1 = os.path.join(tmp_dir, "video1.mp4")
+            video2 = os.path.join(tmp_dir, "video2.mp4")
+            output = os.path.join(tmp_dir, "output.mp4")
+
+            with open(video1, "w") as f:
+                f.write("fake")
+            with open(video2, "w") as f:
+                f.write("fake")
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+
+                concatenate_videos([video1, video2], output)
+
+                mock_run.assert_called_once()
+                cmd = mock_run.call_args[0][0]
+                assert "ffmpeg" in cmd
+                assert "-f" in cmd
+                assert "concat" in cmd
+                assert "-c" in cmd
+                assert "copy" in cmd
+                assert "-movflags" in cmd
+                assert "+faststart" in cmd
+
+    def test_raises_on_ffmpeg_failure(self):
+        """Test that RuntimeError is raised when ffmpeg fails."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            video1 = os.path.join(tmp_dir, "video1.mp4")
+            output = os.path.join(tmp_dir, "output.mp4")
+
+            with open(video1, "w") as f:
+                f.write("fake")
+
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=1,
+                    stderr=b"ffmpeg error message"
+                )
+
+                with pytest.raises(RuntimeError, match="ffmpeg concat failed"):
+                    concatenate_videos([video1], output)
+
+
+class TestUploadCompilationToGCS:
+    def test_uploads_video_file(self):
+        """Test uploading compilation to GCS."""
+        mock_blob = MagicMock()
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as f:
+            f.write(b"fake video content")
+            tmp_path = f.name
+
+        try:
+            url = upload_compilation_to_gcs(
+                mock_client, "test-bucket", tmp_path, "2025/01/compilations/test.mp4"
+            )
+
+            mock_bucket.blob.assert_called_once_with("2025/01/compilations/test.mp4")
+            mock_blob.upload_from_filename.assert_called_once()
+            assert "test-bucket" in url
+            assert "test.mp4" in url
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestGetVideoDuration:
+    def test_returns_duration_from_ffprobe(self):
+        """Test getting video duration."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=b"15.5"
+            )
+
+            duration = get_video_duration("/tmp/video.mp4")
+
+            assert duration == 15.5
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert "ffprobe" in cmd
+
+    def test_returns_zero_on_failure(self):
+        """Test returns 0 when ffprobe fails."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout=b"")
+
+            duration = get_video_duration("/tmp/video.mp4")
+
+            assert duration == 0.0
+
+
+class TestGenerateCompilation:
+    def test_returns_cached_when_exists(self):
+        """Test returns cached compilation when it exists."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+        mock_blob.size = 100000000
+        mock_blob.updated = datetime(2025, 1, 24, 10, 30, 0)
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = generate_compilation(
+            mock_client, "test-bucket", year=2025, month=1, time_filter="sunset"
+        )
+
+        assert result["cached"] is True
+        assert "url" in result
+
+    def test_generates_when_not_cached(self):
+        """Test generates compilation when not cached."""
+        # First call to check_compilation_exists returns not exists
+        mock_blob_not_exists = MagicMock()
+        mock_blob_not_exists.exists.return_value = False
+
+        # Video blob
+        mock_video_blob = MagicMock()
+        mock_video_blob.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob_not_exists
+        mock_bucket.list_blobs.return_value = [mock_video_blob]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        with patch("concat.download_video_from_gcs"), \
+             patch("concat.concatenate_videos"), \
+             patch("concat.upload_compilation_to_gcs", return_value="https://test.url"), \
+             patch("concat.get_video_duration", return_value=15.0), \
+             patch("os.path.getsize", return_value=1000000):
+
+            result = generate_compilation(
+                mock_client, "test-bucket", year=2025, month=1, time_filter="sunset"
+            )
+
+        assert result["cached"] is False
+        assert result["video_count"] == 1
+        assert result["duration_seconds"] == 15.0
+
+    def test_raises_when_no_videos(self):
+        """Test raises ValueError when no videos found."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = False
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.list_blobs.return_value = []
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        with pytest.raises(ValueError, match="No videos found"):
+            generate_compilation(
+                mock_client, "test-bucket", year=2025, month=1, time_filter="sunset"
+            )
+
+    def test_force_regenerate_ignores_cache(self):
+        """Test force_regenerate=True ignores cached compilation."""
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+
+        mock_video_blob = MagicMock()
+        mock_video_blob.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_bucket.list_blobs.return_value = [mock_video_blob]
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        with patch("concat.download_video_from_gcs"), \
+             patch("concat.concatenate_videos"), \
+             patch("concat.upload_compilation_to_gcs", return_value="https://test.url"), \
+             patch("concat.get_video_duration", return_value=15.0), \
+             patch("os.path.getsize", return_value=1000000):
+
+            result = generate_compilation(
+                mock_client, "test-bucket", year=2025, month=1,
+                time_filter="sunset", force_regenerate=True
+            )
+
+        # Should regenerate even though cached exists
+        assert result["cached"] is False
+
+
+class TestListAvailableMonths:
+    def test_lists_months_with_videos(self):
+        """Test listing months that have videos."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/seacliff-2025-01-24T18:30-00-0800.mp4"
+        mock_blob3 = MagicMock()
+        mock_blob3.name = "2024/12/seacliff-2024-12-15T17:00-00-0800.mp4"
+
+        # Mock for compilation checks
+        mock_compilation_blob = MagicMock()
+        mock_compilation_blob.exists.return_value = False
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2, mock_blob3]
+        mock_bucket.blob.return_value = mock_compilation_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_available_months(mock_client, "test-bucket")
+
+        assert len(result) >= 1
+        # Results should be sorted descending by year/month
+        assert result[0]["year"] >= result[-1]["year"]
+
+    def test_excludes_compilations_from_listing(self):
+        """Test that compilation files don't create phantom months."""
+        mock_blob1 = MagicMock()
+        mock_blob1.name = "2025/01/seacliff-2025-01-24T07:00-00-0800.mp4"
+        mock_blob2 = MagicMock()
+        mock_blob2.name = "2025/01/compilations/sunset-2025-01.mp4"
+
+        mock_compilation_blob = MagicMock()
+        mock_compilation_blob.exists.return_value = False
+
+        mock_bucket = MagicMock()
+        mock_bucket.list_blobs.return_value = [mock_blob1, mock_blob2]
+        mock_bucket.blob.return_value = mock_compilation_blob
+
+        mock_client = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+
+        result = list_available_months(mock_client, "test-bucket")
+
+        # Should only have one month
+        assert len(result) == 1
+
+
+class TestTimeRanges:
+    def test_sunrise_range(self):
+        """Test sunrise hour range constants."""
+        assert SUNRISE_HOUR_RANGE == (5, 10)
+
+    def test_sunset_range(self):
+        """Test sunset hour range constants."""
+        assert SUNSET_HOUR_RANGE == (16, 21)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ websocket-client
 websockets    # For WebSocket testing and additional functionality
 yt-dlp
 Pillow            # Image manipulation for collage generation
+jinja2            # HTML template rendering
+aiofiles          # Async static file serving

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,317 @@
+/**
+ * Beach Sunrise/Sunset Gallery Application
+ *
+ * Single-page app for browsing and playing monthly video compilations.
+ */
+
+// DOM Elements
+const loadingEl = document.getElementById('loading');
+const monthsGridEl = document.getElementById('months-grid');
+const videoPlayerEl = document.getElementById('video-player');
+const playerTitleEl = document.getElementById('player-title');
+const closePlayerBtn = document.getElementById('close-player');
+const videoEl = document.getElementById('video');
+const videoSourceEl = document.getElementById('video-source');
+const playerLoadingEl = document.getElementById('player-loading');
+const playerLoadingTextEl = document.getElementById('player-loading-text');
+const playerMetaEl = document.getElementById('player-meta');
+const yearFilterEl = document.getElementById('year-filter');
+const timeFilterEl = document.getElementById('time-filter');
+
+// State
+let monthsData = [];
+let currentFilter = {
+    year: '',
+    time: ''
+};
+
+// Month names for display
+const monthNames = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+];
+
+/**
+ * Format duration in seconds to MM:SS
+ */
+function formatDuration(seconds) {
+    if (!seconds) return '--:--';
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Format file size to human readable
+ */
+function formatSize(bytes) {
+    if (!bytes) return '--';
+    const mb = bytes / (1024 * 1024);
+    if (mb < 1000) {
+        return `${mb.toFixed(1)} MB`;
+    }
+    return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+/**
+ * Get collage thumbnail URL for a month
+ */
+function getCollageUrl(year, month, timeFilter) {
+    const filter = timeFilter ? `-${timeFilter}` : '';
+    return `https://storage.googleapis.com/fogcat-webcam/${year}/${month.toString().padStart(2, '0')}/collages/collage-${year}-${month.toString().padStart(2, '0')}${filter}-5x6.jpg`;
+}
+
+/**
+ * Fetch available months from API
+ */
+async function fetchMonths() {
+    try {
+        const response = await fetch('/api/months');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        return data.months || [];
+    } catch (error) {
+        console.error('Error fetching months:', error);
+        throw error;
+    }
+}
+
+/**
+ * Generate or retrieve a compilation
+ */
+async function generateCompilation(year, month, timeFilter) {
+    const params = new URLSearchParams({
+        year: year.toString(),
+        month: month.toString()
+    });
+    if (timeFilter) {
+        params.append('time_filter', timeFilter);
+    }
+
+    const response = await fetch(`/api/compilation/generate?${params}`, {
+        method: 'POST'
+    });
+
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || 'Failed to generate compilation');
+    }
+
+    return response.json();
+}
+
+/**
+ * Create a month card element
+ */
+function createMonthCard(monthData) {
+    const card = document.createElement('div');
+    card.className = 'month-card';
+    card.dataset.year = monthData.year;
+    card.dataset.month = monthData.month;
+
+    const monthName = monthNames[monthData.month - 1];
+    const collageUrl = getCollageUrl(monthData.year, monthData.month, currentFilter.time || null);
+
+    card.innerHTML = `
+        <div class="thumbnail">
+            <img src="${collageUrl}" alt="${monthName} ${monthData.year}"
+                 onerror="this.parentElement.innerHTML='<div class=\\'placeholder\\'>&#127749;</div>'">
+        </div>
+        <div class="info">
+            <div class="month-title">${monthName} ${monthData.year}</div>
+            <div class="counts">
+                <div class="count-item sunrise" title="Sunrise videos">
+                    &#127749; ${monthData.sunrise_count}
+                </div>
+                <div class="count-item sunset" title="Sunset videos">
+                    &#127751; ${monthData.sunset_count}
+                </div>
+            </div>
+            <div class="compilation-status">
+                ${monthData.has_sunrise_compilation ? '<span class="badge cached">Sunrise ready</span>' : ''}
+                ${monthData.has_sunset_compilation ? '<span class="badge cached">Sunset ready</span>' : ''}
+                ${monthData.has_all_compilation ? '<span class="badge cached">All ready</span>' : ''}
+                ${!monthData.has_sunrise_compilation && !monthData.has_sunset_compilation && !monthData.has_all_compilation ? '<span class="badge not-cached">Not compiled</span>' : ''}
+            </div>
+            <div class="actions">
+                <button class="action-btn sunrise" data-filter="sunrise" title="Play sunrise compilation">
+                    &#127749; Sunrise
+                </button>
+                <button class="action-btn sunset" data-filter="sunset" title="Play sunset compilation">
+                    &#127751; Sunset
+                </button>
+                <button class="action-btn all" data-filter="" title="Play all videos">
+                    All
+                </button>
+            </div>
+        </div>
+    `;
+
+    // Add click handlers for action buttons
+    card.querySelectorAll('.action-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const filter = btn.dataset.filter || null;
+            playCompilation(monthData.year, monthData.month, filter);
+        });
+    });
+
+    return card;
+}
+
+/**
+ * Render the months grid
+ */
+function renderMonths() {
+    monthsGridEl.innerHTML = '';
+
+    // Filter months based on current filters
+    let filtered = monthsData;
+
+    if (currentFilter.year) {
+        filtered = filtered.filter(m => m.year.toString() === currentFilter.year);
+    }
+
+    if (currentFilter.time === 'sunrise') {
+        filtered = filtered.filter(m => m.sunrise_count > 0);
+    } else if (currentFilter.time === 'sunset') {
+        filtered = filtered.filter(m => m.sunset_count > 0);
+    }
+
+    if (filtered.length === 0) {
+        monthsGridEl.innerHTML = `
+            <div class="empty-state">
+                <h3>No videos found</h3>
+                <p>Try adjusting your filters</p>
+            </div>
+        `;
+        return;
+    }
+
+    filtered.forEach(monthData => {
+        monthsGridEl.appendChild(createMonthCard(monthData));
+    });
+}
+
+/**
+ * Populate year filter dropdown
+ */
+function populateYearFilter() {
+    const years = [...new Set(monthsData.map(m => m.year))].sort((a, b) => b - a);
+
+    yearFilterEl.innerHTML = '<option value="">All Years</option>';
+    years.forEach(year => {
+        const option = document.createElement('option');
+        option.value = year;
+        option.textContent = year;
+        yearFilterEl.appendChild(option);
+    });
+}
+
+/**
+ * Play a compilation video
+ */
+async function playCompilation(year, month, timeFilter) {
+    const monthName = monthNames[month - 1];
+    const filterName = timeFilter === 'sunrise' ? 'Sunrises' :
+                       timeFilter === 'sunset' ? 'Sunsets' : 'All Videos';
+
+    playerTitleEl.textContent = `${monthName} ${year} - ${filterName}`;
+    videoPlayerEl.classList.remove('hidden');
+    playerLoadingEl.classList.remove('hidden');
+    playerLoadingTextEl.textContent = 'Loading compilation...';
+    videoEl.style.display = 'none';
+    playerMetaEl.innerHTML = '';
+
+    // Scroll to player
+    videoPlayerEl.scrollIntoView({ behavior: 'smooth' });
+
+    try {
+        const result = await generateCompilation(year, month, timeFilter);
+
+        // Update meta info
+        playerMetaEl.innerHTML = `
+            <div class="meta-item">
+                <span class="meta-label">Videos:</span> ${result.video_count || '--'}
+            </div>
+            <div class="meta-item">
+                <span class="meta-label">Duration:</span> ${formatDuration(result.duration_seconds)}
+            </div>
+            <div class="meta-item">
+                <span class="meta-label">Size:</span> ${formatSize(result.size_bytes)}
+            </div>
+            <div class="meta-item">
+                <span class="meta-label">Status:</span> ${result.cached ? 'Cached' : 'Generated'}
+            </div>
+        `;
+
+        // Load video
+        videoSourceEl.src = result.url;
+        videoEl.load();
+        videoEl.style.display = 'block';
+        playerLoadingEl.classList.add('hidden');
+
+        // Auto-play
+        videoEl.play().catch(err => {
+            console.log('Auto-play prevented:', err);
+        });
+
+    } catch (error) {
+        console.error('Error loading compilation:', error);
+        playerLoadingTextEl.textContent = `Error: ${error.message}`;
+    }
+}
+
+/**
+ * Close the video player
+ */
+function closePlayer() {
+    videoEl.pause();
+    videoPlayerEl.classList.add('hidden');
+}
+
+/**
+ * Initialize the application
+ */
+async function init() {
+    // Set up event listeners
+    closePlayerBtn.addEventListener('click', closePlayer);
+
+    yearFilterEl.addEventListener('change', (e) => {
+        currentFilter.year = e.target.value;
+        renderMonths();
+    });
+
+    timeFilterEl.addEventListener('change', (e) => {
+        currentFilter.time = e.target.value;
+        renderMonths();
+    });
+
+    // Allow closing player with Escape key
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !videoPlayerEl.classList.contains('hidden')) {
+            closePlayer();
+        }
+    });
+
+    // Fetch and display months
+    try {
+        monthsData = await fetchMonths();
+        populateYearFilter();
+        loadingEl.style.display = 'none';
+        renderMonths();
+    } catch (error) {
+        loadingEl.innerHTML = `
+            <div class="error-state">
+                <h3>Failed to load gallery</h3>
+                <p>${error.message}</p>
+                <button onclick="location.reload()">Retry</button>
+            </div>
+        `;
+    }
+}
+
+// Start the app when DOM is ready
+document.addEventListener('DOMContentLoaded', init);

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Beach Sunrise/Sunset Gallery</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Beach Sunrise/Sunset Gallery</h1>
+            <div class="filters">
+                <label for="year-filter">Year:</label>
+                <select id="year-filter">
+                    <option value="">All Years</option>
+                </select>
+
+                <label for="time-filter">Time:</label>
+                <select id="time-filter">
+                    <option value="">All</option>
+                    <option value="sunrise">Sunrise</option>
+                    <option value="sunset">Sunset</option>
+                </select>
+            </div>
+        </header>
+
+        <main>
+            <div id="loading" class="loading">
+                <div class="spinner"></div>
+                <p>Loading months...</p>
+            </div>
+
+            <div id="months-grid" class="months-grid"></div>
+
+            <div id="video-player" class="video-player hidden">
+                <div class="player-header">
+                    <h2 id="player-title"></h2>
+                    <button id="close-player" class="close-btn">&times;</button>
+                </div>
+                <div class="player-content">
+                    <video id="video" controls>
+                        <source id="video-source" type="video/mp4">
+                        Your browser does not support the video tag.
+                    </video>
+                    <div id="player-loading" class="player-loading hidden">
+                        <div class="spinner"></div>
+                        <p id="player-loading-text">Generating compilation...</p>
+                    </div>
+                </div>
+                <div class="player-meta" id="player-meta"></div>
+            </div>
+        </main>
+
+        <footer>
+            <p>Seacliff Beach Camera Compilations</p>
+        </footer>
+    </div>
+
+    <script src="/static/app.js"></script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,402 @@
+/* Reset and base styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    color: #e8e8e8;
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+h1 {
+    font-size: 1.8rem;
+    background: linear-gradient(90deg, #ff9966, #ff5e62);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.filters {
+    display: flex;
+    gap: 15px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.filters label {
+    font-size: 0.9rem;
+    color: #aaa;
+}
+
+.filters select {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.1);
+    color: #e8e8e8;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: border-color 0.3s, background 0.3s;
+}
+
+.filters select:hover {
+    border-color: rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.filters select:focus {
+    outline: none;
+    border-color: #ff9966;
+}
+
+/* Loading state */
+.loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 60px;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid rgba(255, 255, 255, 0.1);
+    border-top-color: #ff9966;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.loading p {
+    margin-top: 15px;
+    color: #aaa;
+}
+
+/* Months grid */
+.months-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.month-card {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.3s, box-shadow 0.3s;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.month-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    border-color: rgba(255, 153, 102, 0.5);
+}
+
+.month-card .thumbnail {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+    background: rgba(0, 0, 0, 0.3);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.month-card .thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.month-card .thumbnail .placeholder {
+    font-size: 3rem;
+    opacity: 0.3;
+}
+
+.month-card .info {
+    padding: 15px;
+}
+
+.month-card .month-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.month-card .counts {
+    display: flex;
+    gap: 15px;
+    font-size: 0.9rem;
+    color: #aaa;
+}
+
+.month-card .count-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.month-card .count-item.sunrise {
+    color: #ffcc80;
+}
+
+.month-card .count-item.sunset {
+    color: #ff8a65;
+}
+
+.month-card .compilation-status {
+    margin-top: 10px;
+    font-size: 0.8rem;
+}
+
+.month-card .compilation-status .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 4px;
+    margin-right: 5px;
+    font-size: 0.75rem;
+}
+
+.month-card .compilation-status .badge.cached {
+    background: rgba(76, 175, 80, 0.2);
+    color: #81c784;
+}
+
+.month-card .compilation-status .badge.not-cached {
+    background: rgba(158, 158, 158, 0.2);
+    color: #9e9e9e;
+}
+
+/* Video player */
+.video-player {
+    margin-top: 30px;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.video-player.hidden {
+    display: none;
+}
+
+.player-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 20px;
+    background: rgba(0, 0, 0, 0.3);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.player-header h2 {
+    font-size: 1.2rem;
+    font-weight: 500;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    color: #aaa;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 5px 10px;
+    transition: color 0.3s;
+}
+
+.close-btn:hover {
+    color: #ff5e62;
+}
+
+.player-content {
+    position: relative;
+    background: #000;
+}
+
+.player-content video {
+    width: 100%;
+    max-height: 70vh;
+    display: block;
+}
+
+.player-loading {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.player-loading.hidden {
+    display: none;
+}
+
+.player-loading p {
+    margin-top: 15px;
+    color: #aaa;
+}
+
+.player-meta {
+    padding: 15px 20px;
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+    font-size: 0.9rem;
+    color: #aaa;
+}
+
+.player-meta .meta-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.player-meta .meta-label {
+    color: #888;
+}
+
+/* Action buttons in month card */
+.month-card .actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
+    padding-top: 15px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.month-card .action-btn {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.3s, transform 0.2s;
+}
+
+.month-card .action-btn.sunrise {
+    background: linear-gradient(135deg, #ffcc80, #ffab40);
+    color: #1a1a2e;
+}
+
+.month-card .action-btn.sunset {
+    background: linear-gradient(135deg, #ff8a65, #ff5722);
+    color: #fff;
+}
+
+.month-card .action-btn.all {
+    background: linear-gradient(135deg, #b39ddb, #7e57c2);
+    color: #fff;
+}
+
+.month-card .action-btn:hover {
+    transform: scale(1.02);
+}
+
+.month-card .action-btn:active {
+    transform: scale(0.98);
+}
+
+/* Footer */
+footer {
+    margin-top: 40px;
+    padding-top: 20px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    text-align: center;
+    color: #666;
+    font-size: 0.85rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    header {
+        flex-direction: column;
+        gap: 15px;
+        text-align: center;
+    }
+
+    h1 {
+        font-size: 1.4rem;
+    }
+
+    .filters {
+        justify-content: center;
+    }
+
+    .months-grid {
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    }
+
+    .month-card .actions {
+        flex-direction: column;
+    }
+}
+
+/* Empty state */
+.empty-state {
+    text-align: center;
+    padding: 60px 20px;
+    color: #888;
+}
+
+.empty-state h3 {
+    font-size: 1.2rem;
+    margin-bottom: 10px;
+}
+
+/* Error state */
+.error-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: #ff5e62;
+    background: rgba(255, 94, 98, 0.1);
+    border-radius: 12px;
+    margin: 20px 0;
+}
+
+.error-state h3 {
+    margin-bottom: 10px;
+}
+
+.error-state button {
+    margin-top: 15px;
+    padding: 10px 20px;
+    background: #ff5e62;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary

- Add video concatenation module (`concat.py`) for creating monthly sunrise/sunset compilations using ffmpeg
- Add API endpoints for listing months and generating/retrieving cached compilations
- Add single-page gallery app for browsing and playing compilation videos
- Cache generated compilations in GCS under `compilations/` directory

## New Features

### API Endpoints
- `GET /api/months` - List available months with video counts and compilation status
- `POST /api/compilation/generate` - Generate or retrieve a monthly compilation (cached)
- `GET /api/compilation/{year}/{month}` - Check compilation status/metadata
- `GET /gallery` - Serve the gallery SPA

### Video Concatenation
- Uses ffmpeg concat demuxer (no re-encoding, fast)
- Filters videos by sunrise/sunset time ranges
- Caches compilations in GCS for future requests

### Gallery UI
- Grid layout with month cards showing thumbnails from existing collages
- Filter by year and sunrise/sunset
- Video player with metadata display
- Responsive design

## Test plan
- [x] All 145 tests pass (`pytest -v`)
- [ ] Test API endpoints manually with curl
- [ ] Verify gallery loads and plays videos
- [ ] Check GCS for cached compilations

## Files Changed
| File | Description |
|------|-------------|
| `concat.py` | Video concatenation module |
| `concat_test.py` | 33 tests for concatenation |
| `app.py` | API endpoints and static file serving |
| `app_test.py` | 15 new endpoint tests |
| `static/` | Gallery SPA (HTML, CSS, JS) |
| `Dockerfile` | Copy new files |
| `requirements.txt` | Add jinja2, aiofiles |

🤖 Generated with [Claude Code](https://claude.ai/code)